### PR TITLE
Disable renovate for pnpm overrides

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -73,6 +73,10 @@
         "automerge": true
       },
       {
+        "matchDepTypes": ["pnpm.overrides"],
+        "enabled": false
+      },
+      {
         "matchUpdateTypes": ["patch"],
         "matchDepTypes": ["devDependencies", "dependencies"],
         "excludeDepNames": ["pnpm"],

--- a/ember.json
+++ b/ember.json
@@ -39,22 +39,22 @@
       { "extends": ["helpers:pinGitHubActionDigests"], "automerge": true },
       {
         "extends": ["monorepo:babel"],
-        "matchUpdateTypes": ["patch", "minor"],
+        "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       },
       {
         "extends": ["monorepo:datadog-browser-sdk"],
-        "matchUpdateTypes": ["patch", "minor"],
+        "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       },
       {
         "extends": ["github>smile-io/renovate-config:ember/testing-packages"],
-        "matchUpdateTypes": ["patch", "minor"],
+        "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       },
       {
         "extends": ["github>smile-io/renovate-config:ember/styling-packages"],
-        "matchUpdateTypes": ["patch", "minor"],
+        "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       },
       {
@@ -64,16 +64,17 @@
           "ace-builds",
           "npm-run-all2"
         ],
-        "matchUpdateTypes": ["patch", "minor"],
+        "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       },
       {
-        "matchUpdateTypes": ["patch", "minor"],
         "matchDepTypes": ["engines", "volta", "packageManager", "final"],
+        "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       },
       {
         "matchDepTypes": ["pnpm.overrides"],
+        "matchUpdateTypes": ["major", "minor"],
         "enabled": false
       },
       {


### PR DESCRIPTION
This disables renovate updates for `pnpm` overrides. Is causing a lot of noise lately with security vulnerability packages.