### PR TITLE
Re-enable renovate during BFCM

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "description": "Common Ember configuration rules",
     "extends": [
       ":disableRateLimiting",

--- a/ember.json
+++ b/ember.json
@@ -1,8 +1,6 @@
 {
   "common": {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "description": "Common Ember configuration rules",
-    "enabled": false,
     "extends": [
       ":disableRateLimiting",
       ":prNotPending",


### PR DESCRIPTION
This re-enables renovate and instead disables it only for `smile-admin` since that's the only repo where we want code freeze.

smile-io/smile-admin#8368