### PR TITLE
Automerge posthog-js minor or patch updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -63,7 +63,8 @@
           "@datadog/datadog-ci",
           "@release-it-plugins/lerna-changelog",
           "ace-builds",
-          "npm-run-all2"
+          "npm-run-all2",
+          "posthog-js"
         ],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true


### PR DESCRIPTION
Add Renovate bot rule to auto-merge posthog-js minor and patch dependency updates to reduce noise with daily pull request open.