### PR TITLE
chore: auto-merge minor and patch globals package updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -61,8 +61,8 @@
       {
         "matchDepNames": [
           "@datadog/datadog-ci",
-          "@release-it-plugins/lerna-changelog",
           "ace-builds",
+          "globals",
           "npm-run-all2"
         ],
         "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary

Add the `globals` package to the auto-merge list in the common Ember Renovate preset. This allows minor and patch updates to `globals` to be auto-merged, reducing manual review overhead for low-risk dependency updates.

## Changes

- Added `globals` to the `matchDepNames` list in the existing auto-merge package rule in `ember.json` (common preset)
