### PR TITLE
chore: auto-merge posthog-js minor & patch updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -63,7 +63,8 @@
           "@datadog/datadog-ci",
           "ace-builds",
           "globals",
-          "npm-run-all2"
+          "npm-run-all2",
+          "posthog-js"
         ],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true


### PR DESCRIPTION
## What

Add `posthog-js` to the list of packages that Renovate auto-merges for minor and patch updates.

## Why

`posthog-js` minor and patch updates are low-risk and don't need manual review. Auto-merging reduces PR noise and keeps the dependency current automatically.

## Changes

- Added `posthog-js` to the `matchDepNames` array in the existing auto-merge rule for minor & patch updates in `ember.json`
