### PR TITLE
chore: automerge patch & minor for @ember-intl/lint and webpack

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -61,10 +61,12 @@
       {
         "matchDepNames": [
           "@datadog/datadog-ci",
+          "@ember-intl/lint",
           "ace-builds",
           "globals",
           "npm-run-all2",
-          "posthog-js"
+          "posthog-js",
+          "webpack"
         ],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true


### PR DESCRIPTION
## What

Add `@ember-intl/lint` and `webpack` to the list of packages that automerge on patch & minor updates.

## Why

These packages were requiring manual merges for routine updates:

- **`@ember-intl/lint`** — lint rules for ember-intl. Low risk since it only affects linting, not runtime behavior.
- **`webpack`** — follows semver strictly at v5.x. Patch and minor updates are safe, and CI validates before merge.

## Changes

Added both packages to the existing `matchDepNames` list in `ember/common` that automerges `["minor", "patch"]` updates.
