### PR TITLE
chore: automerge lint-staged minor+patch updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -64,6 +64,7 @@
           "@ember-intl/lint",
           "ace-builds",
           "globals",
+          "lint-staged",
           "npm-run-all2",
           "posthog-js",
           "webpack"


### PR DESCRIPTION
Adds `lint-staged` to the list of packages that auto-merge on minor and patch updates.

This enables auto-merging for PRs like https://github.com/smile-io/smile-admin/pull/8845 (lint-staged 16.2.7 → 16.3.0).
