### PR TITLE
feat: automerge @typescript-eslint patch & minor updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -62,6 +62,8 @@
         "matchDepNames": [
           "@datadog/datadog-ci",
           "@ember-intl/lint",
+          "@typescript-eslint/eslint-plugin",
+          "@typescript-eslint/parser",
           "ace-builds",
           "globals",
           "lint-staged",


### PR DESCRIPTION
Add `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` to the automerge list for minor and patch updates.

These packages follow semver and are safe to auto-merge for non-major bumps.

Ref: https://github.com/smile-io/smile-admin/pull/8908
