### PR TITLE
Add 5-day stability period for GitHub Action digest updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -37,7 +37,12 @@
         "matchUpdateTypes": ["digest", "minor", "patch"],
         "automerge": true
       },
-      { "extends": ["helpers:pinGitHubActionDigests"], "automerge": true },
+      {
+        "extends": ["helpers:pinGitHubActionDigests"],
+        "automerge": true,
+        "minimumReleaseAge": "5 days",
+        "internalChecksFilter": "strict"
+      },
       {
         "extends": ["monorepo:babel"],
         "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary

Adds a **5-day stability period** (`minimumReleaseAge`) to the `helpers:pinGitHubActionDigests` Renovate rule before automerging GitHub Action digest pin updates.

## Context

This is related to the **Engineering Steering Committee** decision (announced by Alex on Slack) to require that *all* GitHub Actions we use (both directly and transitively) must always use SHA-pinned versions. Tag versioning is no longer allowed, as this is being treated as a critical security issue in response to persistent supply chain attacks.

The org-wide enforcement of SHA1 pinning is planned for **April 2nd**. This PR ensures that even after Renovate detects new digests, we wait 5 days before automerging — providing a defensive window against compromised actions being merged before the community can detect and report them.

## What changed

In `ember.json`, the `helpers:pinGitHubActionDigests` rule now includes:

- **`minimumReleaseAge: "5 days"`** — Renovate waits 5 days after a new digest is published before creating/merging the PR
- **`internalChecksFilter: "strict"`** — Ensures Renovate won't even create the PR until the age threshold is met (vs. creating it but holding the merge)

The existing `automerge: true` is preserved — after the 5-day stability window, updates still merge automatically.
