### PR TITLE
chore: automerge patch & minor @faker-js/faker updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -67,6 +67,7 @@
         "matchDepNames": [
           "@datadog/datadog-ci",
           "@ember-intl/lint",
+          "@faker-js/faker",
           "@typescript-eslint/eslint-plugin",
           "@typescript-eslint/parser",
           "ace-builds",


### PR DESCRIPTION
## Summary

Add `@faker-js/faker` to the list of packages that Renovate will auto-merge for patch and minor updates.

`@faker-js/faker` is a dev-only testing utility used for generating fake data in tests. Patch and minor updates are safe to auto-merge as they follow semver and don't introduce breaking changes.

## Changes

- Added `@faker-js/faker` to the `matchDepNames` array in the existing auto-merge rule for patch & minor updates in `ember.json`
