### PR TITLE
fix: remove automerge from Docker and GitHub Action digest updates

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -39,7 +39,6 @@
       },
       {
         "extends": ["helpers:pinGitHubActionDigests"],
-        "automerge": true,
         "minimumReleaseAge": "5 days",
         "internalChecksFilter": "strict"
       },
@@ -99,8 +98,7 @@
         "automerge": true
       },
       {
-        "extends": ["docker:pinDigests"],
-        "automerge": true
+        "extends": ["docker:pinDigests"]
       }
     ]
   },


### PR DESCRIPTION
## Problem

Our Renovate config enforces a 5-day stability window (`minimumReleaseAge: "5 days"` + `internalChecksFilter: "strict"`) for all npm dependencies as a supply chain protection measure. However, Docker digest and GitHub Action digest updates were set to `automerge: true` — and **digest update types do not support `minimumReleaseAge`** (no `releaseTimestamp` is available from the datasource).

This means these digest updates were automerging immediately, completely bypassing the 5-day gate we intended for everything else.

**References:**
- [Renovate docs — minimumReleaseAge support by update type](https://docs.renovatebot.com/key-concepts/minimum-release-age/)
- [renovatebot/renovate#38212 — Docker digests don't support minimumReleaseAge](https://github.com/renovatebot/renovate/discussions/38212)
- [renovatebot/renovate#38656 — Tracking: add timestamp support for Docker digests](https://github.com/renovatebot/renovate/issues/38656)

## Solution

Remove `automerge: true` from both rules so digest updates open PRs for human review instead:

- **`docker:pinDigests`** — removed `automerge`
- **`helpers:pinGitHubActionDigests`** — removed `automerge`, kept `minimumReleaseAge` and `internalChecksFilter` (these still work for version updates like major/minor/patch)

## Linked Task

ACT-1607
