### PR TITLE
Silence major/minor updates for pnpm-workspace.yaml overrides

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -90,6 +90,11 @@
         "enabled": false
       },
       {
+        "matchManagers": ["pnpm-workspace"],
+        "matchUpdateTypes": ["major", "minor"],
+        "enabled": false
+      },
+      {
         "matchUpdateTypes": ["patch"],
         "matchDepTypes": ["devDependencies", "dependencies"],
         "excludeDepNames": ["pnpm"],


### PR DESCRIPTION
## Summary

- The `ember/common` preset's rule disabling major/minor updates on `pnpm.overrides` only matches entries whose depType is tagged `pnpm.overrides` by Renovate's `npm` manager (i.e. `package.json` → `pnpm.overrides`). Once a repo moves overrides to `pnpm-workspace.yaml` (required for pnpm v10+), Renovate's separate `pnpm-workspace` manager handles them and the existing rule silently becomes a no-op.
- Add a sibling rule that matches the `pnpm-workspace` manager directly so the suppression covers both locations.

## Why

`ember-smile-core` just migrated overrides to `pnpm-workspace.yaml` as part of the pnpm v11 upgrade and immediately got 23 Renovate PRs (#1650–#1672) proposing major bumps to override pins that are intentional ceilings for transitive deps (e.g. `brace-expansion@^1` → v2/v3/v4/v5, `express@4.21.2>path-to-regexp` → v1…v8, `anymatch>picomatch` → v3/v4, `cross-spawn@^5` → v7). `smile-admin` migrated earlier and shows the same gap: a major-version PR on `axios` (an override-only dep) was opened despite the existing rule, confirming the rule isn't reaching the new manager.

## Test plan

- [ ] Verify Renovate stops proposing major/minor bumps for entries under `overrides:` in `pnpm-workspace.yaml` once consumers pick this up (the existing `package.json`-based behavior is preserved by the original rule).
- [ ] Close the 23 stale PRs in `ember-smile-core` after the preset propagates; confirm Renovate does not reopen them.
- [ ] Patch updates on overrides still flow through (rule only disables `major`/`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)