### PR TITLE
Expand Renovate automerge coverage and fix broken rules

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -47,6 +47,11 @@
         "internalChecksFilter": "strict"
       },
       {
+        "matchManagers": ["github-actions"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "automerge": true
+      },
+      {
         "extends": ["monorepo:babel"],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true

--- a/ember.json
+++ b/ember.json
@@ -23,6 +23,9 @@
     "lockFileMaintenance": {
       "automerge": true
     },
+    "vulnerabilityAlerts": {
+      "automerge": true
+    },
     "packageRules": [
       {
         "matchDatasources": ["npm"],

--- a/ember.json
+++ b/ember.json
@@ -84,6 +84,7 @@
           "@typescript-eslint/eslint-plugin",
           "@typescript-eslint/parser",
           "ace-builds",
+          "ember-eslint-parser",
           "globals",
           "lint-staged",
           "npm-run-all2",

--- a/ember.json
+++ b/ember.json
@@ -20,6 +20,9 @@
       "github>smile-io/renovate-config:ember/styling",
       "github>smile-io/renovate-config:ember/testing"
     ],
+    "lockFileMaintenance": {
+      "automerge": true
+    },
     "packageRules": [
       {
         "matchDatasources": ["npm"],

--- a/ember.json
+++ b/ember.json
@@ -38,7 +38,11 @@
         "automerge": true
       },
       {
-        "extends": ["helpers:pinGitHubActionDigests"],
+        "extends": ["helpers:pinGitHubActionDigests"]
+      },
+      {
+        "matchDepTypes": ["action"],
+        "matchUpdateTypes": ["major", "minor", "patch"],
         "minimumReleaseAge": "5 days",
         "internalChecksFilter": "strict"
       },

--- a/ember.json
+++ b/ember.json
@@ -53,6 +53,11 @@
         "automerge": true
       },
       {
+        "extends": ["packages:jsUnitTest"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "automerge": true
+      },
+      {
         "extends": ["github>smile-io/renovate-config:ember/testing-packages"],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
@@ -186,14 +191,18 @@
   },
 
   "testing-packages": {
-    "description": "Testing packages",
-    "extends": ["packages:jsUnitTest"],
-    "matchDepNames": ["@ember/test-helpers", "ember-try"]
+    "description": "Testing packages not covered by packages:jsUnitTest",
+    "matchPackageNames": ["@ember/test-helpers", "ember-try"]
   },
 
   "testing": {
     "description": "Group all testing dependencies",
     "packageRules": [
+      {
+        "groupName": "testing dependencies",
+        "groupSlug": "testing",
+        "extends": ["packages:jsUnitTest"]
+      },
       {
         "groupName": "testing dependencies",
         "groupSlug": "testing",

--- a/ember.json
+++ b/ember.json
@@ -8,6 +8,8 @@
       ":labels(internal,dependencies, 'Category: KTLO')",
       ":enableVulnerabilityAlertsWithLabel(security,internal,dependencies,'Category: KTLO')",
       ":separateMultipleMajorReleases",
+      ":timezone(America/Toronto)",
+      "schedule:automergeOfficeHours",
       "group:embroiderMonorepo",
       "group:glimmer",
       "group:linters",
@@ -23,6 +25,7 @@
     "lockFileMaintenance": {
       "automerge": true
     },
+    "platformAutomerge": false,
     "vulnerabilityAlerts": {
       "automerge": true
     },


### PR DESCRIPTION
# Why

Analysis of renovate PRs in smile-admin (past quarter: 116 merged - 73 automerged, 43 human-merged at a median of 1 day, i.e. rubber-stamps) surfaced two broken rules and several easy automerge wins. Discussion notes: humans weren't adding scrutiny on these classes of updates, CI is the real gate, and since merges auto-deploy we gate automerge to office hours instead of relying on a human click.

# What

One commit per change, in order:

1. **Fix `testing-packages` matching no packages** - the preset combined `extends: [packages:jsUnitTest]` with `matchDepNames`, and matchers inside a single packageRule AND together, so the testing group/automerge rules matched nothing (observed: sinon minors human-merged). Split into parallel rules.
2. **Scope the GitHub Action 5-day age gate to version updates** - digest re-pins have no `releaseTimestamp` (unsupported by design, renovatebot/renovate#39058, #43144); since Renovate 42 (`timestamp-required` default) they were stuck "Pending" forever and never became PRs. Maintainer-recommended workaround. Note: this means digest re-pins get no cooldown at all - they can't - but they remain manual-merge (see below), so a human still reviews every SHA change.
3. **Automerge GitHub Action minor/patch version updates** - consistently rubber-stamped (10+ last quarter); gated by the 5-day age check (which works for tag updates) + CI. Digest-only re-pins deliberately stay manual (d682c7c).
4. **Automerge `ember-eslint-parser` minor/patch** - falls through both linter paths: not matched by `packages:linters` patterns, and excluded by the `>= 1.0.0` guard (it's 0.x). 4 of its last 5 updates were rubber-stamped.
5. **Automerge lock file maintenance** - only fires when checks pass, so the common failure mode (artifact update errors) still surfaces for manual attention.
6. **Automerge vulnerability alert PRs** - security pins currently sit open until someone clicks; the opposite of what we want.
7. **Restrict automerge to office hours (America/Toronto)** - merges auto-deploy org-wide, so no unobserved night/weekend deploys. Requires `platformAutomerge: false`: GitHub-native auto-merge enqueues at PR creation and ignores `automergeSchedule`.

# Trade-offs

- `platformAutomerge: false` means automerges land on the next renovate run within the office-hours window, not the instant CI goes green. Acceptable latency for observability.
- Timezone/window are easy to tune later (`schedule:automergeOfficeHours` = 8:00-17:59 Mon-Fri).

# Validation

- `renovate-config-validator` passes for `common` and `testing`; `testing-packages` reports the same standalone rule-fragment notice as the pre-existing `styling-packages` (these presets are only valid inside `packageRules.extends`).
- Pre-existing migration warning (`excludeDepNames` -> `matchDepNames: ["!pnpm"]`) untouched; can do as a follow-up.

# Deliberately not included

- `:automergeStableNonMajor` (broad prod-dep automerge) - parked until test coverage on key repos justifies it.
- Allowlist additions for runtime-affecting deps (axios etc.) - case-by-case.

