### PR TITLE
Automerge updates to our own GitHub Actions

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -61,6 +61,22 @@
         "automerge": true
       },
       {
+        "description": "Auto-merge digest updates to our own GitHub Actions (review happens at the source repo; age gating can't evaluate digests anyway)",
+        "matchManagers": ["github-actions"],
+        "matchDepNames": ["smile-io/**"],
+        "matchUpdateTypes": ["digest"],
+        "automerge": true
+      },
+      {
+        "description": "Auto-merge minor/patch updates to our own GitHub Actions immediately, skipping the third-party supply-chain age gate",
+        "matchManagers": ["github-actions"],
+        "matchDepNames": ["smile-io/**"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "minimumReleaseAge": "0",
+        "internalChecksFilter": "none",
+        "automerge": true
+      },
+      {
         "extends": ["monorepo:babel"],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true


### PR DESCRIPTION
# Why

We pin all GitHub Actions to SHA digests (`helpers:pinGitHubActionDigests`) to defend against **third-party** supply-chain attacks - a compromised maintainer, a hijacked `v4` tag, a poisoned release sitting in the wild. The 5-day age gate exists for the same reason: give the ecosystem time to surface a bad release before we pull it.

That threat model doesn't apply to our own `smile-io/*` actions:

- There's no public ecosystem to "catch" a poisoned release, so the age gate buys nothing - it just delays our own fixes propagating.
- The right place to review a change to a first-party action is **a reviewed PR in the action's own repo**, not a rubber-stamp on every downstream re-pin (which nobody meaningfully audits anyway).

Pinning and auto-merging are orthogonal: we keep pinning everything to SHAs (immutable, reproducible, auditable refs in every consumer) - we just decide the *bump PR* for a first-party action doesn't need a human.

This follows up on #22, which deliberately left **all** digest re-pins manual. This carves out first-party actions from that decision while leaving third-party re-pins manual as before.

# What

Two `packageRules` scoped to `smile-io/**` GitHub Actions, added after the existing github-actions rules so they override the inherited age gate:

1. **Automerge digest updates.** Digest re-pins have no `releaseTimestamp`, so they can't be age-gated (renovatebot/renovate#39058, #43144) - #22 scoped the 5-day gate to version updates precisely because digests would otherwise hang "Pending" forever. For first-party we don't need the cooldown or the manual review, so we just automerge.
2. **Drop the 5-day age gate on minor/patch.** So our own action releases propagate immediately instead of after a 5-day wait. `minimumReleaseAge: "0"` is massaged to `null` by Renovate (`config/massage.js` → `toMs("0") === 0`), cleanly removing the inherited constraint; `internalChecksFilter: "none"` keeps them from being filtered as pending.

```jsonc
{
  "matchManagers": ["github-actions"],
  "matchDepNames": ["smile-io/**"],
  "matchUpdateTypes": ["digest"],
  "automerge": true
},
{
  "matchManagers": ["github-actions"],
  "matchDepNames": ["smile-io/**"],
  "matchUpdateTypes": ["minor", "patch"],
  "minimumReleaseAge": "0",
  "internalChecksFilter": "none",
  "automerge": true
}
```

# Scope / trade-offs

- **Major updates stay manual**, even for first-party - a major bump implies a breaking interface change the consumer must adapt to.
- Both rules inherit `schedule:automergeOfficeHours` and `platformAutomerge: false`, so first-party automerges still land only within the office-hours window, and **CI remains the real gate**.
- **Residual risk:** auto-merging first-party digest bumps means a compromised `smile-io/*` action repo would propagate to consumers fast, with no downstream gate. The mitigation is branch protection + required reviews on the action repos themselves - the review moves to the source, where it's meaningful.

# Validation

- `renovate-config-validator` passes for the `common` preset (only the pre-existing `excludeDepNames` → `matchDepNames: ["!pnpm"]` migration notice from #22 remains, untouched).
- Confirmed `matchDepNames: ["smile-io/**"]` glob, `matchUpdateTypes: ["digest"]`, and `minimumReleaseAge: "0"` → `null` massaging against the Renovate runtime.