### PR TITLE
Remove office-hours restriction on automerge

### DIFF
--- a/ember.json
+++ b/ember.json
@@ -9,7 +9,6 @@
       ":enableVulnerabilityAlertsWithLabel(security,internal,dependencies,'Category: KTLO')",
       ":separateMultipleMajorReleases",
       ":timezone(America/Toronto)",
-      "schedule:automergeOfficeHours",
       "group:embroiderMonorepo",
       "group:glimmer",
       "group:linters",
@@ -25,7 +24,6 @@
     "lockFileMaintenance": {
       "automerge": true
     },
-    "platformAutomerge": false,
     "vulnerabilityAlerts": {
       "automerge": true
     },


### PR DESCRIPTION
## What

Removes the `schedule:automergeOfficeHours` preset (and the now-unneeded `"platformAutomerge": false`) from the Ember `common` config so automerges fire as soon as checks pass, any time of day.

## Why

The office-hours schedule (added in #22) limited automerging to weekday office hours (8-17 Mon-Fri, `America/Toronto`). PRs that went green outside that window sat unmerged until the next morning - e.g. [smile-io/ember-smile-core#1776](https://github.com/smile-io/ember-smile-core/pull/1776), which should have merged immediately.

## Details

- **Drop `schedule:automergeOfficeHours`** - the time restriction itself.
- **Drop `"platformAutomerge": false`** - this was only set so `automergeSchedule` would be honored (GitHub-native automerge ignores schedules). With the schedule gone, restoring the default (`true`) lets native automerge enqueue at PR creation and merge the moment checks pass.
- **Keep `:timezone(America/Toronto)`** - still governs the `every weekend` patch-grouping schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)